### PR TITLE
Fix default quill color

### DIFF
--- a/src/app/myinfo/page.tsx
+++ b/src/app/myinfo/page.tsx
@@ -28,29 +28,29 @@ const MyInfo = () => {
   const [isOpenErrorModal, setIsOpenErrorModal] = useState(false);
   const [isOpenDeleteModal, setIsOpenDeleteModal] = useState(false);
   const [isOpenPasswordModal, setIsOpenPasswordModal] = useState(false);
-  // const [state, setState] = useState({
-  //   nickName: "",
-  //   phoneNumber: "",
-  // });
+  const [state, setState] = useState({
+    nickName: "",
+    phoneNumber: "",
+  });
 
   // const { nickName, phoneNumber } = state;
 
-  // const { mutate } = useEditMyInfo(state);
+  const { mutate } = useEditMyInfo(state);
 
   const handleChange = async (e: FormEvent) => {
     e.preventDefault();
     // if (myInfo.nickName !== nickName && !nickNameValidation)
     //   return alert("닉네임 검증을 해주세요.");
 
-    // mutate();
+    mutate();
   };
 
-  // useEffect(() => {
-  //   setState({
-  //     nickName: myInfo?.nickName || "",
-  //     phoneNumber: myInfo?.phoneNumber || "",
-  //   });
-  // }, [myInfo]);
+  useEffect(() => {
+    setState({
+      nickName: myInfo?.nickName || "",
+      phoneNumber: myInfo?.phoneNumber || "",
+    });
+  }, [myInfo]);
 
   if (!myInfo) return null;
   const { gender } = myInfo;

--- a/src/components/templates/write/Editor.tsx
+++ b/src/components/templates/write/Editor.tsx
@@ -2,8 +2,6 @@ import * as React from "react";
 import dynamic from "next/dynamic";
 import styled from "styled-components";
 
-import COLORS from "@/ui/colors";
-
 const Quill = dynamic(() => import("@/utils/Quill"), { ssr: false }); // client 사이드에서만 동작되기 때문에 ssr false로 설정
 
 interface Props {
@@ -22,7 +20,6 @@ const Editor = ({ value, onChange }: Props) => {
 export default Editor;
 
 const EditorContainer = styled.div`
-  color: ${COLORS.TEXT01};
   width: 100%;
   margin: 0 auto 40px;
 `;

--- a/src/utils/Quill.tsx
+++ b/src/utils/Quill.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import Compressor from "compressorjs";
 
 import api from "@/apis/client";
+import COLORS from "@/ui/colors";
 
 interface IEditor {
   value: string;
@@ -138,6 +139,7 @@ const Quill: NextPage<IEditor> = ({ value, onChange }) => {
 export default Quill;
 
 const CustomReactQuill = styled(ReactQuill)`
+  color: ${COLORS.TEXT01};
   height: 682px;
   @media (max-width: 768px) {
     height: 540px;

--- a/src/utils/ReadQuill.tsx
+++ b/src/utils/ReadQuill.tsx
@@ -3,6 +3,8 @@ import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
 import styled from "styled-components";
 
+import COLORS from "@/ui/colors";
+
 interface IEditor {
   value: string;
 }
@@ -14,6 +16,7 @@ const ReadQuill: NextPage<IEditor> = ({ value }) => {
 export default ReadQuill;
 
 const CustomReactQuill = styled(ReactQuill)`
+  color: ${COLORS.TEXT01};
   .ql-toolbar {
     display: none;
   }


### PR DESCRIPTION
### Quill에 색상 기본값 추가
- 유저의 시스템 색상이 다크모드인 경우 `/write` 페이지와 `/post` 페이지의 게시글에서 글자가 흰색으로 나오는 버그 존재
- Quill의 기본 색상을 `COLORS.TEXT01`로 변경

### MyInfo 페이지에서 '수정' 버튼 롤백